### PR TITLE
Fix centroid bug

### DIFF
--- a/geovoronoi/_voronoi.py
+++ b/geovoronoi/_voronoi.py
@@ -11,7 +11,7 @@ import logging
 import numpy as np
 from scipy.spatial import Voronoi
 from scipy.spatial.distance import cdist
-from shapely.geometry import LineString, asPoint
+from shapely.geometry import LineString, asPoint, MultiPoint
 from shapely.ops import polygonize, cascaded_union
 
 from ._geom import polygon_around_center
@@ -100,7 +100,7 @@ def polygon_lines_from_voronoi(vor, geo_shape, return_only_poly_lines=True):
     xrange = xmax - xmin
     yrange = ymax - ymin
     max_dim_extend = max(xrange, yrange)
-    center = np.array(geo_shape.centroid)
+    center = np.array(MultiPoint(vor.points).convex_hull.centroid)
 
     # generate lists of full polygon lines, loose ridges and far points of loose ridges from scipy Voronoi result object
     poly_lines = []


### PR DESCRIPTION
Hello Markus,

I just encountered a bug and wrote a small fix. The bug occurs when the centroid of the
boundary area `geo_shape` lies outside the convex hull of the generating point set.
Then, some of the normals that define the far points point inwards instead of outwards.
In my case, this meant that `far_points_hull` was fully disjoint with the generating set and
the union `far_points_hull.union(geo_shape)` was a MultiPolygon instead of a Polygon, which
broke the code.

To fix, I chose to use the generators' convex hull's centroid as a reference point instead. I don't know which of shapely or scipy for generating the convex hull is the better choice, but this code fixes the bug.

The data I used that produced the bug is the following:
```python
coords = np.array([[0,0],[1,0],[0.6,0.3],[0.2,0.456]])
geo_shape = Polygon([(-0.2,-0.2), (1.2,-0.2), (1.2,1.0), (0.0,0.7)])
```

Cheers, Malte